### PR TITLE
Add SQLite persistence for activities and registrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.log
 *.sql
 *.sqlite
+*.db
 
 # OS generated files #
 ######################

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Persist activities and registrations in SQLite
 
 ## Getting Started
 
@@ -31,6 +32,19 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity                                         |
+
+## Database Initialization
+
+- The API now stores data in `src/activities.db` using SQLite.
+- On first run, the database is created and seeded with the default activity data.
+- On subsequent runs, existing data is reused (no reset on restart).
+
+To reset to default seeded data, delete the database file and restart the app:
+
+```
+rm src/activities.db
+```
 
 ## Data Model
 
@@ -47,4 +61,4 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+All activity and registration data is persisted in SQLite.


### PR DESCRIPTION
This pull request migrates the application's data storage from in-memory to persistent storage using SQLite, enabling activities and registrations to be retained across server restarts. It also introduces a new endpoint for unregistering students from activities and updates the documentation to reflect these changes.

**Database persistence and initialization:**

* Added SQLite-based persistence for activities and registrations, including database initialization and seeding with default data on first run (`src/app.py`, `src/README.md`). [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R12) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R81-R174) [[3]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R9) [[4]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R35-R47) [[5]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5L50-R64)

**API changes:**

* Replaced in-memory data access with database queries for all activity and registration endpoints (`src/app.py`). [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L22-R24) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L88-L131)
* Added a new `DELETE` endpoint `/activities/{activity_name}/unregister` to allow students to unregister from activities (`src/app.py`, `src/README.md`). [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L88-L131) [[2]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R35-R47)

**Documentation updates:**

* Updated `src/README.md` to describe the new persistent storage, database initialization, and how to reset the database (`src/README.md`). [[1]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R35-R47) [[2]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5L50-R64)